### PR TITLE
Adiciona Google Tag Manager na página

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
-source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer'
+ruby '2.4.2'
+
+source 'https://rubygems.org' do
+  gem 'github-pages', group: :jekyll_plugins
+  gem 'html-proofer'
+  gem 'jekyll'
+  gem 'minitest'
+  gem 'rake'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     pathutil (0.16.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
+    rake (12.2.1)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -226,8 +227,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages
-  html-proofer
+  github-pages!
+  html-proofer!
+  jekyll!
+  minitest!
+  rake!
+
+RUBY VERSION
+   ruby 2.4.2p198
 
 BUNDLED WITH
    1.16.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+require 'jekyll'
+require 'bundler'
+
+task :default => :build
+
+task :preview => [:clean, :build ] do
+  jekyll('serve --watch')
+end
+
+task :build do
+  jekyll('build')
+end
+
+task :test => [:clean, :build ] do
+  Dir.glob('./test/*_test.rb').each { |file| require file}
+end
+
+task :clean do
+  cleanup
+end
+
+def jekyll(directives = '')
+  sh 'jekyll ' + directives
+end
+
+# remove generated site
+def cleanup
+  sh 'rm -rf _site'
+end

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
-exclude: [deploy_rsa.enc, vendor]
+exclude: [deploy_rsa.enc, vendor, test, Gemfile, Gemfile.lock, Rakefile, README.md]
 sass:
   style: compressed

--- a/_data/google.yml
+++ b/_data/google.yml
@@ -1,0 +1,2 @@
+---
+gtm: "GTM-KXXD45C"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,10 +4,21 @@
     <title>Vaga Lume</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ site.data.google.gtm }}');</script>
+    <!-- End Google Tag Manager -->
     <link href="https://fonts.googleapis.com/css?family=Amatic+SC:400,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.data.google.gtm }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <a name="top"></a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,10 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Amatic+SC:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
-    <link href="https://fonts.googleapis.com/css?family=Amatic+SC:400,700" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet">
   </head>
   <body>
     <a name="top"></a>

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-bundle exec jekyll build
-bundle exec htmlproofer --assume-extension --check_html ./_site
+bundle exec rake test

--- a/test/htmlproofer_test.rb
+++ b/test/htmlproofer_test.rb
@@ -1,0 +1,9 @@
+require 'html-proofer'
+require 'minitest/autorun'
+
+class HTMLProoferTest < Minitest::Test
+  def test_run_proofer
+    options = { :assume_extension => true, :check_html => true}
+    HTMLProofer.check_directory("./_site", options).run
+  end
+end

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -1,0 +1,21 @@
+require 'minitest/autorun'
+require 'nokogiri'
+require 'yaml'
+
+class IndexTest < Minitest::Test
+
+  def setup
+    @doc = Nokogiri::HTML(File.open('_site/index.html'))
+    @google_id = YAML.load_file('_data/google.yml')['gtm']
+  end
+
+  def test_gtm_esta_definido_no_head
+    gtm_script_tag = @doc.xpath(%Q{/html/head/script[contains(., "#{@google_id}")]})
+    refute_empty(gtm_script_tag, '<head> deveria conter <script> com configuração do Google Tag Manager')
+  end
+
+  def test_gtm_esta_definido_como_primeiro_filho_do_body
+    gtm_script_tag = @doc.xpath(%Q{/html/body/*[1]/iframe[contains(@src, "#{@google_id}")]})
+    refute_empty(gtm_script_tag, 'O primeiro elemento do <body> deveria ser a configuração do Google Tag Manager')
+  end
+end


### PR DESCRIPTION
A adição do GTM é bem simples. Adicionei dois snippets de código, um no `<head>` e outro no `<body>` que estavam no cartão [Incluir script do GTM na home](https://trello.com/c/gaTqMddl).

Achei legal tirar o id do html e colocar em um arquivo de configuração. No Jekyll, esse tipo de informação fica em arquivos `.yml` localizados no diretório `_data`.

Criei testes utilizando a biblioteca **Nokogiri** para verificar que o código gerado contém o ID do google no lugar certo. Para isso, coloquei o Rake como dependência do projeto e utilizei ele para rodar os testes.

Mudei um pouco a sintaxe do Gemfile. Adicionei a versão do ruby para ficar compatível com o arquivo `.ruby-version`. Além disso coloquei as definições das gems dentro de um bloco do método `source`. Essa é a recomendação da [documentação](http://bundler.io/gemfile.html) sobre segurança:

> Global source lines are a security risk and should not be used as they can lead to gems being installed from unintended sources.

Quando `source` é definido globalmente, existe o risco de gems serem baixadas de fontes não desejadas.