### PR TITLE
Pequenos ajustes no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ Siga as instruções descritas em [INSTALL.md](INSTALL.md)
 
 ## Decisões de arquitetura
 
-Saiba mais sobre as decisões de arquitetura tomadas neste projeto em [_doc/decisoes/README.md](doc/decisoes/README.md)
+Saiba mais sobre as decisões de arquitetura tomadas neste projeto em [_doc/decisoes/README.md](_doc/decisoes/README.md)
 
 ## Executando os testes
 
 O site possui uma série de testes para garantir que o html gerado está correto.
 Para executar os testes de corretude, rode `bundle exec rake test`. Existe um
 outro teste mais demorado, que verifica se os links da página apontam para
-páginas existentes. Para rodá-los, execute `bundle exec rake acceptance`.
+páginas existentes. Para rodá-los, execute `bundle exec rake integration`.
 
 ## Rodando o site localmente
 
@@ -125,7 +125,6 @@ Este script realiza os seguintes passos:
 4. Versiona o site e salva em `staging`
 
 O último passo não será rodado localmente.
-
 
 [chruby]: https://github.com/postmodern/chruby
 [jekyll]: https://jekyllrb.com


### PR DESCRIPTION
Durante o processo de aprender um pouco sobre o projeto e rodar alguns comandos descritos no README, notei que um comando não existia mais e que um link não estava funcionando.

- Alterando task `bundle exec rake acceptance` para `bundle exec rake integration`

Ao executar o comando `bundle exec rake acceptance` obtive o erro:

```
rake aborted!
Don't know how to build task 'acceptance' (see --tasks)
```

E ao executar o comando `bundle exec rake --tasks` foi possível ver que existia uma task `integration` que fazia sentido a descrição do README.

```
rake build         # Compila o site
rake clean         # Limpa o workspace
rake integration   # Executa os testes de links externos
rake preview       # Sobe o site localmente com jekyll serve
rake rspec         # Executa os testes unitários
rake rspec_report  # Executa os testes unitários e gera relatório
rake test          # Executa o teste de html e os testes unitários
```

- O link para a documentação referente as decisões de arquitetura não estava funcionando.

https://github.com/associacao-vagalume/vagalume.org.br/blob/master/_doc/decisoes/README.md